### PR TITLE
chore: upgrade checkout-with-app action dependencies

### DIFF
--- a/checkout-with-app/action.yml
+++ b/checkout-with-app/action.yml
@@ -54,7 +54,7 @@ runs:
     - name: Generate GitHub App Token
       id: app-token
       if: inputs.github_app_auth != 'false'
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_pem }}
@@ -63,7 +63,7 @@ runs:
           ${{ inputs.github_app_repos }}
     
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: ${{ inputs.fetch_depth }}


### PR DESCRIPTION
## Summary
- upgrade `actions/create-github-app-token` from `v2` to `v3`
- upgrade `actions/checkout` from `v4` to `v6`
- move the `checkout-with-app` wrapper onto Node 24-compatible action majors

## Why
`checkout-with-app` is a composite wrapper used by `zondax/_workflows`. The wrapper itself is fine, but it was still transitively pulling Node 20-era action majors, which keeps GitHub runtime deprecation warnings alive in consuming workflows.

## Validation
- parsed `checkout-with-app/action.yml` locally with Ruby YAML
- confirmed no remaining `actions/checkout@v4` or `actions/create-github-app-token@v2` refs remain in this repo
